### PR TITLE
better ifname regexp

### DIFF
--- a/grafana/provisioning/dashboards/Mikrotik-snmp-prometheus.json
+++ b/grafana/provisioning/dashboards/Mikrotik-snmp-prometheus.json
@@ -8636,7 +8636,7 @@
           "refId": "Prometheus-Interface-Variable-Query"
         },
         "refresh": 1,
-        "regex": "/ifName=\"(.*)\",instance/",
+        "regex": "/ifName=\"(.*?)\"/",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",


### PR DESCRIPTION
Before regexp for isolating interface names was relying on the the next tag in query to be exactly "instance", which were generating few issues:
  - if there is another tag starting with the word "interface"
  - if the next tag is not "interface" then the interface name extracted are not valid.

The proposed regexp is solving that issues