### PR TITLE
RX/TX Sum: make unit bytes, not bits

### DIFF
--- a/Mikrotik-snmp-prometheus.json
+++ b/Mikrotik-snmp-prometheus.json
@@ -2654,7 +2654,7 @@
             "properties": [
               {
                 "id": "unit",
-                "value": "bits"
+                "value": "bytes"
               },
               {
                 "id": "thresholds",
@@ -2686,7 +2686,7 @@
             "properties": [
               {
                 "id": "unit",
-                "value": "bits"
+                "value": "bytes"
               },
               {
                 "id": "thresholds",

--- a/grafana/provisioning/dashboards/Mikrotik-snmp-prometheus.json
+++ b/grafana/provisioning/dashboards/Mikrotik-snmp-prometheus.json
@@ -2654,7 +2654,7 @@
             "properties": [
               {
                 "id": "unit",
-                "value": "bits"
+                "value": "bytes"
               },
               {
                 "id": "thresholds",
@@ -2686,7 +2686,7 @@
             "properties": [
               {
                 "id": "unit",
-                "value": "bits"
+                "value": "bytes"
               },
               {
                 "id": "thresholds",


### PR DESCRIPTION
the metrics are called mtxrInterfaceStats{Rx,Tx}Bytes, so bits is not correct